### PR TITLE
build(deps): add @octokit/core >= 3 as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
   "devDependencies": {
     "semantic-release": "^17.1.2"
   },
+  "peerDependencies": {
+    "@octokit/core": ">=3"
+  },
   "release": {
     "branches": [
       "main"


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
Add `@octokit/core` as `peerDependency` with a version equal or greater than 3.

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix #53 