### PR TITLE
fix(create-package-json): add @octokit/core >= 3 as peerDependency fo…

### DIFF
--- a/lib/create-package-json.js
+++ b/lib/create-package-json.js
@@ -2,6 +2,10 @@ module.exports = createPackageJson;
 
 const writePrettyFile = require("./write-pretty-file");
 
+const OCTOKIT_PLUGIN_PAIR_DEPENDENCIES = {
+  "@octokit/core": ">= 3",
+};
+
 async function createPackageJson(answers) {
   const pkg = {
     name: answers.packageName,
@@ -20,6 +24,7 @@ async function createPackageJson(answers) {
     license: "MIT",
     dependencies: {},
     devDependencies: {},
+    peerDependencies: {},
     jest: {
       preset: "ts-jest",
       coverageThreshold: {
@@ -66,6 +71,9 @@ async function createPackageJson(answers) {
   }
   if (answers.supportsBrowsers) {
     pkg["@pika/pack"].pipeline.push(["@pika/plugin-build-web"]);
+  }
+  if (answers.isPlugin) {
+    Object.assign(pkg.peerDependencies, OCTOKIT_PLUGIN_PAIR_DEPENDENCIES);
   }
 
   await writePrettyFile("package.json", JSON.stringify(pkg));

--- a/lib/create-package-json.js
+++ b/lib/create-package-json.js
@@ -2,7 +2,7 @@ module.exports = createPackageJson;
 
 const writePrettyFile = require("./write-pretty-file");
 
-const OCTOKIT_PLUGIN_PAIR_DEPENDENCIES = {
+const OCTOKIT_PLUGIN_PEER_DEPENDENCIES = {
   "@octokit/core": ">= 3",
 };
 
@@ -73,7 +73,7 @@ async function createPackageJson(answers) {
     pkg["@pika/pack"].pipeline.push(["@pika/plugin-build-web"]);
   }
   if (answers.isPlugin) {
-    Object.assign(pkg.peerDependencies, OCTOKIT_PLUGIN_PAIR_DEPENDENCIES);
+    Object.assign(pkg.peerDependencies, OCTOKIT_PLUGIN_PEER_DEPENDENCIES);
   }
 
   await writePrettyFile("package.json", JSON.stringify(pkg));


### PR DESCRIPTION
## 📝 Summary
<!--- Provide a general summary of your changes, and if you feel that the commit comments are not descriptive enough, give more detail of your changes -->
`@octokit/core` is added as peerDependency with version 3 or greater for Octokit generated Projects which are Plugins.

## ⛱ Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix #55 