### PR TITLE
feat(issue templates): add link to discussion forum

### DIFF
--- a/create-octokit-project.js
+++ b/create-octokit-project.js
@@ -141,7 +141,7 @@ async function main() {
     await command("git add README.md");
     await command("git commit -m 'docs(README): initial version'");
 
-    await createIssueTemplates(answers.packageName);
+    await createIssueTemplates(useOctokitOrg);
     await command("git add .github/ISSUE_TEMPLATE");
     await command("git commit -m 'docs(ISSUE_TEMPLATES): initial version'");
 

--- a/lib/create-issue-templates.js
+++ b/lib/create-issue-templates.js
@@ -2,7 +2,66 @@ module.exports = createIssueTemplates;
 
 const writePrettyFile = require("./write-pretty-file");
 
-async function createIssueTemplates(packageName) {
+async function createIssueTemplates(isOctokitOrg) {
+  if (isOctokitOrg) {
+    await writePrettyFile(
+      ".github/ISSUE_TEMPLATE/01_bug.md",
+      `---
+  name: "🐛 Bug Report"
+  about: "If something isn't working as expected 🤔"
+  labels: bug
+  ---
+  
+  <!-- Please replace all placeholders such as this below -->
+  
+  **What happened?**
+  
+  <!-- Describe the problem and how to reproduce it. Add screenshots or a link to your repository if helpful. Ideally create a reproducible test case on runkit.com (Example: https://runkit.com/gr2m/octokit-rest-js-1808) -->
+  
+  **What did you expect to happen?**
+  
+  <!-- Describe what you expected to happen instead -->
+  
+  **What the problem might be**
+  
+  <!-- If you have an idea where the bug might lie, please share here. Otherwise remove the whole section -->
+  `
+    );
+    await writePrettyFile(
+      ".github/ISSUE_TEMPLATE/02_feature_request.md",
+      `---
+  name: "🧚‍♂️ Feature Request"
+  about: "Wouldn’t it be nice if 💭"
+  labels: feature
+  ---
+  
+  <!-- Please replace all placeholders such as this below -->
+  
+  **What’s missing?**
+  
+  <!-- Describe your feature idea  -->
+  
+  **Why?**
+  
+  <!-- Describe the problem you are facing -->
+  
+  **Alternatives you tried**
+  
+  <!-- Describe the workarounds you tried so far and how they worked for you -->
+  `
+    );
+
+    await writePrettyFile(
+      ".github/ISSUE_TEMPLATE/config.yml",
+      `blank_issues_enabled: false
+  contact_links:
+    - name: 🆘 I need Help
+      url: https://github.com/octokit/rest.js/discussions
+      about: Got a question? An idea? Feedback? Start here.`
+    );
+    return;
+  }
+
   await writePrettyFile(
     ".github/ISSUE_TEMPLATE/01_help.md",
     `---
@@ -57,29 +116,6 @@ labels: feature
 **Alternatives you tried**
 
 <!-- Describe the workarounds you tried so far and how they worked for you -->
-`
-  );
-  await writePrettyFile(
-    ".github/ISSUE_TEMPLATE/04_thanks.md",
-    `---
-name: "💝 Thank you"
-about: "${packageName} is awesome 🙌"
-labels: thanks
----
-
-<!-- Please replace all placeholders such as this below -->
-
-**How do you use ${packageName}?**
-
-<!-- Please share how you use ${packageName}. What are your use cases? -->
-
-**What do you love about it?**
-
-<!-- Thanks for the kind words 🤗 -->
-
-**How did you learn about it?**
-
-<!-- Just curious -->
 `
   );
 }


### PR DESCRIPTION
I am not 100% sure about this one. I like it, but I think we should differentiate whether the repository is created on @octokit or not. If it is not, we should leave the help issue template and do not add the link to the @octokit/rest.js discusssion forum