### PR TITLE
feat(create-test-action): scaffold test action to run lint only once

### DIFF
--- a/lib/create-test-action.js
+++ b/lib/create-test-action.js
@@ -33,13 +33,15 @@ jobs:
           restore-keys: |
             \${{ runner.os }}-node-
       - run: npm ci
-      - run: npm test
+      - run: npm test --ignore-scripts # run lint only once
     
   test:
     runs-on: ubuntu-latest
     needs: test_matrix
     steps:
-      - run: echo ok
+      - uses: actions/checkout@v2
+      - run: npm ci
+      - run: npm run lint
 `
   );
 }


### PR DESCRIPTION
# Description
Move `npm run lint` as a unique step in the `test` job. This way we run `lint` only once and not for each value in `test_matrix`

# Context
Inspired by https://github.com/octokit/core.js/blob/master/.github/workflows/test.yml