### PR TITLE
ci(package.json): add pretest script with lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "lint": "prettier --check 'lib/*.js' create-octokit-project.js README.md package.json",
     "lint:fix": "prettier --write 'lib/*.js' create-octokit-project.js README.md package.json",
+    "pretest": "npm run -s lint",
     "test": "npm run lint"
   },
   "dependencies": {


### PR DESCRIPTION
To be compliant with the rest of Octokit's ecosystem.