### PR TITLE
fix: mark prettier as a required import to fix an import error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,13 +15,13 @@
         "clipboardy": "^2.3.0",
         "execa": "^5.1.1",
         "inquirer": "^8.2.4",
+        "prettier": "^2.7.1",
         "spdx-license-list": "^6.3.0"
       },
       "bin": {
         "create-octokit-project": "bin/create-octokit-project.js"
       },
       "devDependencies": {
-        "prettier": "^2.7.1",
         "semantic-release": "^19.0.0"
       },
       "engines": {
@@ -5587,7 +5587,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
       "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -10691,8 +10690,7 @@
     "prettier": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
-      "dev": true
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g=="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "clipboardy": "^2.3.0",
     "execa": "^5.1.1",
     "inquirer": "^8.2.4",
+    "prettier": "^2.7.1",
     "spdx-license-list": "^6.3.0"
   },
   "devDependencies": {
-    "prettier": "^2.7.1",
     "semantic-release": "^19.0.0"
   },
   "release": {


### PR DESCRIPTION
```
node:internal/modules/cjs/loader:942
  throw err;
  ^

Error: Cannot find module 'prettier'
Require stack:
- /home/user/.npm/_npx/b52e3113e4f00614/node_modules/create-octokit-project/lib/write-pretty-file.js
- /home/user/.npm/_npx/b52e3113e4f00614/node_modules/create-octokit-project/lib/create-coc.js
- /home/user/.npm/_npx/b52e3113e4f00614/node_modules/create-octokit-project/index.js
- /home/user/.npm/_npx/b52e3113e4f00614/node_modules/create-octokit-project/bin/create-octokit-project.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:939:15)
    at Module._load (node:internal/modules/cjs/loader:780:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/home/user/.npm/_npx/b52e3113e4f00614/node_modules/create-octokit-project/lib/write-pretty-file.js:6:17)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Module._load (node:internal/modules/cjs/loader:827:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/home/user/.npm/_npx/b52e3113e4f00614/node_modules/create-octokit-project/lib/write-pretty-file.js',
    '/home/user/.npm/_npx/b52e3113e4f00614/node_modules/create-octokit-project/lib/create-coc.js',
    '/home/user/.npm/_npx/b52e3113e4f00614/node_modules/create-octokit-project/index.js',
    '/home/user/.npm/_npx/b52e3113e4f00614/node_modules/create-octokit-project/bin/create-octokit-project.js'
  ]
}

Node.js v18.0.0
npm ERR! code 1
npm ERR! path /home/user
npm ERR! command failed
npm ERR! command sh -c create-octokit-project

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/user/.npm/_logs/2022-10-25T21_39_02_465Z-debug-0.log
```