### PR TITLE
fix: use correct github token name

### DIFF
--- a/index.js
+++ b/index.js
@@ -457,7 +457,7 @@ module.exports = async function main() {
     await command(`git add .github/workflows/test.yml`);
     await command(`git commit -m 'ci(test): initial version'`);
 
-    await createUpdatePrettierAction();
+    await createUpdatePrettierAction({ owner });
     await command(`git add .github/workflows/update-prettier.yml`);
     await command(`git commit -m 'ci(update-prettier): initial version'`);
 

--- a/lib/create-update-prettier-action.js
+++ b/lib/create-update-prettier-action.js
@@ -2,7 +2,10 @@ module.exports = createUpdatePrettierAction;
 
 const writePrettyFile = require("./write-pretty-file");
 
-async function createUpdatePrettierAction() {
+async function createUpdatePrettierAction({ owner }) {
+  const githubTokenSecretName =
+    owner === "octokit" ? "OCTOKITBOT_PAT" : "GITHUB_TOKEN";
+
   await writePrettyFile(
     ".github/workflows/update-prettier.yml",
     `name: Update Prettier
@@ -24,7 +27,7 @@ jobs:
       - run: npm run lint:fix
       - uses: gr2m/create-or-update-pull-request-action@v1.x
         env:
-          GITHUB_TOKEN: \${{ secrets.OCTOKITBOT_PAT }}
+          GITHUB_TOKEN: \${{ secrets.${githubTokenSecretName} }}
         with:
           title: "Prettier updated"
           body: "An update to prettier required updates to your code."


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #215 

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `OCTOKITBOT_PAT` was used instead of `GITHUB_TOKEN`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* `OCTOKITBOT_PAT` is used if it's the octokit org, otherwise `GITHUB_TOKEN`


### Other information
<!-- Any other information that is important to this PR  -->

* N/A

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

