### PR TITLE
fix: work around inquirer `answers` is undefined

### DIFF
--- a/lib/prompts.js
+++ b/lib/prompts.js
@@ -24,6 +24,7 @@ function getDefaultRepository(username, answers) {
 }
 
 async function prompts({ username, name, email, website, useOctokitOrg }) {
+  let currentAnswers = {};
   return inquirer.prompt([
     {
       type: "confirm",
@@ -49,9 +50,11 @@ async function prompts({ username, name, email, website, useOctokitOrg }) {
             ? "auth-"
             : "";
         const example = `${scopePrefix}${typePrefix}example`;
+        currentAnswers = answers;
         return `What npm package name should the project have? (Example: ${example})`;
       },
-      validate(input, answers) {
+      validate(input) {
+        const answers = currentAnswers;
         if (answers.isPlugin) {
           const prefix = (useOctokitOrg ? "@octokit/" : "octokit-") + "plugin-";
           if (input.startsWith(prefix)) return true;


### PR DESCRIPTION
There is an issue with `inquirer` where the `answers` argument to the `validation()` function is undefined, according to the docs, that argument should be passed, but it isn't

Fixes #396

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The script would crash because `answers` was undefined

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The script no longer crashes

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

