### PR TITLE
ci: stop testing against NodeJS v18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
           cache: npm
       - name: Install
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "engines": {
-    "node": ">= 18"
+    "node": ">= 20"
   },
   "publishConfig": {
     "provenance": true


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v18